### PR TITLE
Fixes failing otel-collector which fails due to health check extension being …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       - volume_exporter
 
   otel-collector:
-    image: otel/opentelemetry-collector-dev:latest
+    image: otel/opentelemetry-collector-contrib-dev:latest
     command: ["--config=/etc/otel-collector-config.yaml"]
     volumes:
       - ./etc/otel-collector-config.yaml:/etc/otel-collector-config.yaml

--- a/etc/otel-collector-config.yaml
+++ b/etc/otel-collector-config.yaml
@@ -12,7 +12,8 @@ exporters:
 
   jaeger:
     endpoint: tempo:14250
-    insecure: true
+    tls:
+      insecure: true
 
 processors:
   batch:


### PR DESCRIPTION
Fresh `docker-compose up` fails to launch otel collector due to health check extension being moved to contrib (see [this PR](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/4894)). I updated docker-compose.yml to use the `otel/opentelemetry-collector-contrib-dev:latest` image which has the health check extension, and updated the `./etc/otel-collector-config.yaml` to use the updated format to ignore insecure tls setup properly.